### PR TITLE
Fix reproducibility.

### DIFF
--- a/textaugment/eda.py
+++ b/textaugment/eda.py
@@ -48,7 +48,7 @@ class EDA:
                 synonyms.add(synonym)
         if word in synonyms:
             synonyms.remove(word)
-        return sorted(synonyms)
+        return random.shuffle(sorted(synonyms))
 
     @staticmethod
     def swap_word(new_words):

--- a/textaugment/eda.py
+++ b/textaugment/eda.py
@@ -48,7 +48,7 @@ class EDA:
                 synonyms.add(synonym)
         if word in synonyms:
             synonyms.remove(word)
-        return list(synonyms)
+        return sorted(synonyms)
 
     @staticmethod
     def swap_word(new_words):
@@ -187,7 +187,7 @@ class EDA:
         self.sentence = sentence
         words = sentence.split()
         new_words = words.copy()
-        random_word_list = list(set([word for word in words if word not in self.stopwords]))
+        random_word_list = sorted(set([word for word in words if word not in self.stopwords]))
         random.shuffle(random_word_list)
         replaced = 0
         for random_word in random_word_list:

--- a/textaugment/eda.py
+++ b/textaugment/eda.py
@@ -48,7 +48,10 @@ class EDA:
                 synonyms.add(synonym)
         if word in synonyms:
             synonyms.remove(word)
-        return random.shuffle(sorted(synonyms))
+        synonyms = sorted(list(synonyms))
+        random.shuffle(synonyms)
+        return synonyms
+
 
     @staticmethod
     def swap_word(new_words):


### PR DESCRIPTION
The order of words returned by list(set()) is not reproducible, even when the seed of random library is fixed. And this issue can be fixed by return a sorted list.