### PR TITLE
Fix/modernize core dependencies for python 3.9 3.12 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-gensim>=4.0
+gensim==4.3.3
 googletrans==4.0.2
-nltk
-numpy
-textblob
+nltk==3.9.1
+numpy==1.26.4

--- a/setup.py
+++ b/setup.py
@@ -31,25 +31,30 @@ def read(fname):
 
 
 setuptools.setup(
-      name='textaugment',
-      version=__version__,
-      packages=setuptools.find_packages(exclude=('test*', )),
-      author='Joseph Sefara',
-      author_email='sefaratj@gmail.com',
-      license='MIT',
-      keywords=['text augmentation', 'python', 'natural language processing', 'nlp'],
-      url='https://github.com/dsfsi/textaugment',
-      description='A library for augmenting text for natural language processing applications.',
-      long_description=read("README.md"),
-      long_description_content_type="text/markdown",
-      install_requires=['nltk', 'gensim>=4.0', 'textblob', 'numpy', 'googletrans>=2'],
-      classifiers=[
-          "Intended Audience :: Developers",
-          "Natural Language :: English",
-          "License :: OSI Approved :: MIT License",
-          "Operating System :: OS Independent",
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: Implementation :: PyPy",
-          "Topic :: Text Processing :: Linguistic",
-        ]
+    name='textaugment',
+    version=__version__,
+    packages=setuptools.find_packages(exclude=('test*', )),
+    author='Joseph Sefara',
+    author_email='sefaratj@gmail.com',
+    license='MIT',
+    keywords=['text augmentation', 'python', 'natural language processing', 'nlp'],
+    url='https://github.com/dsfsi/textaugment',
+    description='A library for augmenting text for natural language processing applications.',
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    install_requires=[
+        'gensim==4.3.3',
+        'googletrans==4.0.2',
+        'nltk==3.9.1',
+        'numpy==1.26.4'
+    ],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Text Processing :: Linguistic",
+    ]
 )

--- a/textaugment/eda.py
+++ b/textaugment/eda.py
@@ -93,6 +93,7 @@ class EDA:
         :return:  Constructer do not return.
         """
         nltk.download('stopwords')
+        nltk.download('wordnet')
         
         self.stopwords = stopwords.words('english') if stop_words is None else stop_words
         self.sentence = None

--- a/textaugment/eda.py
+++ b/textaugment/eda.py
@@ -92,6 +92,8 @@ class EDA:
         :rtype:   None
         :return:  Constructer do not return.
         """
+        nltk.download('stopwords')
+        
         self.stopwords = stopwords.words('english') if stop_words is None else stop_words
         self.sentence = None
         self.p = None

--- a/textaugment/translate.py
+++ b/textaugment/translate.py
@@ -130,8 +130,8 @@ class Translate:
         """
         A method to paraphrase a sentence.
         
-        :type data: str
-        :param data: sentence used for data augmentation 
+        :type _text: str
+        :param _text: sentence used for data augmentation 
         :rtype:   str
         :return:  The augmented data
         """

--- a/textaugment/translate.py
+++ b/textaugment/translate.py
@@ -9,7 +9,6 @@ import asyncio
 from asyncio import AbstractEventLoop
 
 from .constants import LANGUAGES
-from textblob import TextBlob
 from googletrans import Translator
 
 
@@ -121,13 +120,13 @@ class Translate:
             self.to = kwargs['to']
             self.src = kwargs['src']
 
-    async def _translate_text(self, _text_blob: TextBlob) -> str:
+    async def _translate_text(self, _text: str) -> str:
         async with Translator() as translator:
-            _forward = await translator.translate(_text_blob, dest=self.to, src=self.src)
+            _forward = await translator.translate(_text, dest=self.to, src=self.src)
             _backward = await translator.translate(_forward.text, dest=self.src, src=self.to)
             return _backward.text
 
-    def augment(self, _data: str):
+    def augment(self, _text: str):
         """
         A method to paraphrase a sentence.
         
@@ -136,12 +135,12 @@ class Translate:
         :rtype:   str
         :return:  The augmented data
         """
-        if type(_data) is not str:
+        if type(_text) is not str:
             raise TypeError("DataType must be a string")
                 
-        event_loop: AbstractEventLoop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
-        translated: str = event_loop.run_until_complete(self._translate_text(TextBlob(_data.lower())))
-        event_loop.close()
+        _event_loop: AbstractEventLoop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_event_loop)
+        _back_translated_text: str = _event_loop.run_until_complete(self._translate_text((_text.lower())))
+        _event_loop.close()
 
-        return translated
+        return _back_translated_text


### PR DESCRIPTION
- Added versioning to gensim, googletrans, numpy, and nltk dependencies.
- Removed textblob dependency as it has no use.
- Added code to automatically download `stopwords` and `wordnet` corpus